### PR TITLE
Fixing .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,13 @@
 language: python
+python:
+  "3.6"
+
+cache:
+  pip
+install:
+  pip install coverage
+
+script:
+  python -m unittest discover;
+  coverage run -m unittest discover;
+  coverage report --omit=*test*


### PR DESCRIPTION
Fixed .travis.yml so that it would build properly, run unittest, and provide a coverage report excluding test files