### PR TITLE
Added functionality for opcode 7a and opcode 64

### DIFF
--- a/jvpm/op_codes1.py
+++ b/jvpm/op_codes1.py
@@ -25,6 +25,16 @@ class op_codes:
                 stack_z.append(var1)
                 return stack_z
 
+        def op_code7a(self, stack):    # arithmetic shift right
+                # Assumes values put on the stack have already been converted to decimal integers
+                value = stack.pop()
+                shift_amount = stack.pop
+
+                result = value >> shift_amount
+                stack.append(result)
+
+
+
         def op_code82(stack_z):		#bitwise XOR
                 var1 = stack_z.pop() ^ stack_z.pop()
                 stack_z.append(var1)
@@ -63,6 +73,12 @@ class op_codes:
 
                 stack_z.append(var1)
                 return stack_z
+        def op_code64(self, stack): # subtract
+                # Assumes values put on the stack have already been converted to decimal integers
+                x = stack.pop()
+                y = stack.pop()
+
+                result = x - y
 
         def op_code7e(stack_z): # bitwise and
                 var1 = stack_z.pop() & stack_z.pop()


### PR DESCRIPTION
- These operations both are taking values directly from the stack, and assume that the values on the stack are decimal integers
- This is because I am following the format of everyone else's code, if they are not decimal integers, then a conversion must take place
- This conversion must be done before an item is added to the stack with our current implementation